### PR TITLE
Respect buildLabel query parameter in login & worldState requests

### DIFF
--- a/src/WFClassic.Web/Controllers/WarframeAuthController.cs
+++ b/src/WFClassic.Web/Controllers/WarframeAuthController.cs
@@ -25,6 +25,10 @@ namespace WFClassic.Web.Controllers
         public async Task<IActionResult> PostAsync()
         {
             var request = Utils.GetRequestObject<WarframeLoginRequest>(this.HttpContext);
+            if (this.HttpContext.Request.Query.ContainsKey("buildLabel"))
+            {
+                request.buildLabel = this.HttpContext.Request.Query["buildLabel"];
+            }
             request.UserIpAddress = this.HttpContext.Connection.RemoteIpAddress.MapToIPv4().ToString();
 
             var result = await _warframeLoginHandler.Handle(request);

--- a/src/WFClassic.Web/Logic/Universe/GetState/GetWorldState.cs
+++ b/src/WFClassic.Web/Logic/Universe/GetState/GetWorldState.cs
@@ -9,5 +9,8 @@ namespace WFClassic.Web.Logic.Universe.GetState
 
         [JsonPropertyName("nonce")]
         public long Nonce { get; set; }
+
+        [JsonIgnore]
+        public string buildLabel { get; set; }
     }
 }

--- a/src/WFClassic.Web/Logic/Universe/GetState/GetWorldStateHandler.cs
+++ b/src/WFClassic.Web/Logic/Universe/GetState/GetWorldStateHandler.cs
@@ -66,7 +66,7 @@ namespace WFClassic.Web.Logic.Universe.GetState
             try
             {
                 _logger.LogInformation("GetWorldStateHandler => accountId {AccountID} nonce {Nonce} =>   ", getWorldState.AccountId, getWorldState.Nonce);
-                result.GetWorldStateResultJson = GetWorldStateMapper.Map(worldStateEventMessages, worldStateAlerts,operationConfigurations, _configuration.GetValue<string>("BuildLabel"));
+                result.GetWorldStateResultJson = GetWorldStateMapper.Map(worldStateEventMessages, worldStateAlerts,operationConfigurations, getWorldState.buildLabel ?? _configuration.GetValue<string>("BuildLabel"));
                 _logger.LogInformation("GetWorldStateHandler => accountId {AccountID} nonce {Nonce} =>   ", getWorldState.AccountId, getWorldState.Nonce);
                 result.GetWorldStateResultStatus = GetWorldStateResultStatus.Success;
             }

--- a/src/WFClassic.Web/Logic/WFAuth/WFLogin/WarframeLoginHandler.cs
+++ b/src/WFClassic.Web/Logic/WFAuth/WFLogin/WarframeLoginHandler.cs
@@ -141,7 +141,7 @@ namespace WFClassic.Web.Logic.WFAuth.WFLogin
                 warframeLoginResult.WarframeLoginResultDetails = new WarframeLoginResultDetails()
                 {
                     id = user.Id.ToString(),
-                    BuildLabel = _configuration.GetValue<string>("BuildLabel"),
+                    BuildLabel = warframeLoginRequest.buildLabel ?? _configuration.GetValue<string>("BuildLabel"),
                     DisplayName = user.DisplayName,
                     NatHash = "127.0.0.1:88",
                     Nonce = user.CurrentNonce,

--- a/src/WFClassic.Web/Logic/WFAuth/WFLogin/WarframeLoginRequest.cs
+++ b/src/WFClassic.Web/Logic/WFAuth/WFLogin/WarframeLoginRequest.cs
@@ -12,5 +12,8 @@ namespace WFClassic.Web.Logic.WFAuth.WFLogin
 
         [JsonIgnore]
         public string UserIpAddress { get; set; }
+
+        [JsonIgnore]
+        public string buildLabel { get; set; }
     }
 }


### PR DESCRIPTION
This avoids login failures for Bootstrapper users who didn't configure the appconfig's BuildLabel 'correctly'.